### PR TITLE
docs: update state redundancy report with checkpointer API refactorin…

### DIFF
--- a/docs/20251019_state_redundancy_report.md
+++ b/docs/20251019_state_redundancy_report.md
@@ -1,0 +1,83 @@
+# State Redundancy and Efficiency Report
+
+**Date:** 2025-10-19
+
+**Author:** Jules
+
+## 1. Introduction
+
+This report analyzes the `SimplifiedState` class in `backend/puntini/orchestration/simplified_state.py` to identify redundancies and ambiguities that could impact the efficiency and maintainability of the LangGraph-based agent. The goal is to propose pragmatic improvements for a more streamlined and robust state management strategy, drawing on best practices in agent design.
+
+## 2. Analysis of `SimplifiedState`
+
+The `SimplifiedState` has made significant strides in reducing state bloat by adopting a minimal state pattern. However, a critical review reveals several areas for further improvement.
+
+### 2.1. Redundant Fields
+
+The following fields were identified as redundant or overlapping, leading to potential confusion and unnecessary data management:
+
+*   **`current_node` and `current_step`**: These two fields appear to serve the same purpose: tracking the current position in the graph's execution. `current_node` is sufficient for this purpose, and `current_step` adds unnecessary complexity. LangGraph's internal mechanics already manage the execution flow, so over-reliance on explicit state tracking can be an anti-pattern.
+*   **`retry_count` and `current_attempt`**: These fields are functionally identical. `retry_count` is a more common and intuitive name for this concept. `current_attempt` is redundant.
+
+### 2.2. Ambiguous and Problematic Fields
+
+*   **`result: Optional[Dict[str, Any]]`**: This field is overly generic. Its untyped, "catch-all" nature makes it difficult to trace the data flow between nodes and introduces tight coupling. A node consuming data from `result` must have implicit knowledge of the structure of the data produced by the preceding node. This violates the principle of separation of concerns and makes the graph harder to debug and modify.
+
+*   **Append-Only Lists (`messages`, `artifacts`, `failures`, `progress`, `todo_list`)**: While append-only lists are a valid design pattern, they pose a risk of state bloat in long-running or complex agent executions. As these lists grow, so does the size of the state object, which can lead to increased memory consumption and latency, particularly when serializing and deserializing the state for checkpointing.
+
+## 3. Recommendations for Improvement
+
+To address the identified issues, the following pragmatic changes are recommended:
+
+### 3.1. Eliminate Redundancy
+
+1.  **Remove `current_step`**: Rely on `current_node` as the single source of truth for the current execution step.
+2.  **Remove `current_attempt`**: Standardize on `retry_count` to track retries.
+
+### 3.2. Increase Clarity and Decoupling
+
+1.  **Refactor the `result` field**: Instead of a generic dictionary, consider the following alternatives:
+    *   **Introduce specific, typed fields for node outputs**: For example, `parsed_intent: Optional[IntentSpec]` or `tool_output: Optional[ToolResult]`. This would make the data flow explicit and type-safe.
+    *   **Adopt a more structured approach to context passing**: While `extract_node_context` is a good step, the `result` field still acts as a side-channel. A better approach would be for nodes to return specific, typed objects that are then explicitly mapped to the state.
+
+### 3.3. Mitigate State Bloat
+
+1.  **Implement list truncation**: For lists like `messages` and `failures`, consider keeping only the N most recent items in the state. The full history can be accessed through LangGraph's tracing capabilities if needed.
+2.  **Externalize large artifacts**: For potentially large data like `artifacts`, consider storing them in a separate, persistent store (e.g., a database or file store) and only storing a reference (e.g., a UUID or URI) in the state.
+3.  **Leverage Checkpointing for history**: Remind developers that LangGraph's checkpointing system is the canonical source of execution history. The state should represent the *current* state of the execution, not the entire history.
+
+## 4. Conclusion
+
+By implementing these recommendations, the `SimplifiedState` can be made more efficient, robust, and easier to maintain. These changes will lead to a more scalable and performant agent architecture that is better aligned with the best practices of modern agent design.
+
+## 5. Refactoring Plan for Execution History
+
+To further enhance the state management strategy, we propose a refactoring plan that leverages LangGraph's checkpointer API to represent the execution history. This approach will allow us to remove the append-only lists from the `SimplifiedState`, resulting in a more lightweight and efficient state object.
+
+### 5.1. The Role of the Checkpointer API
+
+The checkpointer API is a powerful feature of LangGraph that provides a persistent record of the agent's execution history. It automatically saves snapshots of the state at each step, allowing for features such as:
+
+*   **Fault tolerance**: The agent can be resumed from the last checkpoint in case of a failure.
+*   **Human-in-the-loop**: The execution can be paused and resumed, allowing for human intervention.
+*   **Auditing and debugging**: The complete execution history can be reviewed for auditing and debugging purposes.
+
+### 5.2. Proposed Refactoring Steps
+
+1.  **Remove Append-Only Lists**: The first step is to remove the `messages`, `artifacts`, `failures`, `progress`, and `todo_list` fields from the `SimplifiedState`.
+
+2.  **Rely on the Checkpointer for History**: Instead of storing the history in the state, we will rely on the checkpointer to provide the historical context when needed. This can be achieved by:
+    *   **Querying the checkpointer**: When a node needs access to historical data (e.g., the last 5 messages), it can query the checkpointer for the relevant information.
+    *   **Passing historical data as context**: The `extract_node_context` function can be updated to query the checkpointer and pass the relevant historical data to the nodes as part of their context.
+
+3.  **Update Node Implementations**: The node implementations will need to be updated to consume the historical data from their context instead of the state.
+
+### 5.3. Benefits of this Approach
+
+This refactoring will provide several benefits:
+
+*   **Reduced State Bloat**: By removing the append-only lists, we will significantly reduce the size of the state object, leading to improved performance and reduced memory consumption.
+*   **Improved Separation of Concerns**: The state will be responsible for representing the *current* state of the execution, while the checkpointer will be responsible for managing the history. This will lead to a cleaner and more maintainable design.
+*   **Enhanced Scalability**: A smaller state object will make it easier to scale the agent to handle more complex and long-running executions.
+
+This refactoring will require a concerted effort, but the long-term benefits in terms of performance, scalability, and maintainability will be well worth the investment.


### PR DESCRIPTION
…g plan

Adds a new section to the `docs/20251019_state_redundancy_report.md` report.

This new section, "Refactoring Plan for Execution History," details a plan to leverage LangGraph's checkpointer API to manage the agent's execution history. This approach will allow for the removal of append-only lists from the `SimplifiedState`, resulting in a more lightweight and efficient state object.

The plan includes the following steps:

-   Removing the append-only lists from the state.
-   Relying on the checkpointer to provide historical context when needed.
-   Updating node implementations to consume historical data from their context.